### PR TITLE
[FIX] connector_carepoint: Fix procurement line creation

### DIFF
--- a/connector_carepoint/models/procurement_order.py
+++ b/connector_carepoint/models/procurement_order.py
@@ -148,7 +148,7 @@ class ProcurementOrderImportMapper(CarepointImportMapper):
         res.update({'origin': sale_id.name,
                     'product_uom': line_id.product_uom.id,
                     'ndc_id': ndc_id.id,
-                    'product_id': line_id.product_id,
+                    'product_id': line_id.product_id.id,
                     })
 
         return res

--- a/connector_carepoint/tests/models/test_procurement_order.py
+++ b/connector_carepoint/tests/models/test_procurement_order.py
@@ -308,7 +308,7 @@ class TestProcurementOrderImportMapper(ProcurementOrderTestBase):
                     'origin': self.unit.binder_for().to_odoo().name,
                     'product_uom': line.product_uom.id,
                     'ndc_id': self.unit.binder_for().to_odoo().id,
-                    'product_id': line.product_id,
+                    'product_id': line.product_id.id,
                 })
 
     def test_order_line_procurement_updates_order_line_proc_vals(self):


### PR DESCRIPTION
- Prefer id of product recordset in ORM vals
