### PR TITLE
[9.0][IMP] Create carepoint product images sync

### DIFF
--- a/connector_carepoint/models/fdb_img_date.py
+++ b/connector_carepoint/models/fdb_img_date.py
@@ -4,6 +4,7 @@
 
 import logging
 from openerp import models, fields
+from openerp.addons.connector.connector import ConnectorUnit
 from openerp.addons.connector.unit.mapper import (mapping,
                                                   )
 from ..unit.backend_adapter import CarepointCRUDAdapter
@@ -21,7 +22,7 @@ class CarepointFdbImgDate(models.Model):
     _inherit = 'carepoint.binding'
     _inherits = {'fdb.img.date': 'odoo_id'}
     _description = 'Carepoint FdbImgDate'
-    _cp_lib = 'fdb_img_date'  # Name of model in Carepoint lib (snake_case)
+    _cp_lib = 'fdb_img_date'
 
     odoo_id = fields.Many2one(
         string='FdbImgDate',
@@ -47,6 +48,18 @@ class FdbImgDateAdapter(CarepointCRUDAdapter):
 
 
 @carepoint
+class FdbImgDateUnit(ConnectorUnit):
+    _model_name = 'carepoint.fdb.img.date'
+
+    def _import_by_unique_id(self, unique_id):
+        """ It imports by CP col ``IMGUNIQID`` """
+        adapter = self.unit_for(FdbImgDateAdapter)
+        importer = self.unit_for(FdbImgDateImporter)
+        for record in adapter.search(IMGUNIQID=unique_id):
+            importer.run(record)
+
+
+@carepoint
 class FdbImgDateBatchImporter(DelayedBatchImporter):
     """ Import the Carepoint FdbImgDates.
     For every product category in the list, a delayed job is created.
@@ -61,15 +74,35 @@ class FdbImgDateImportMapper(CarepointImportMapper):
     direct = [
         ('IMGSTRTDT', 'start_date'),
         ('IMGSTOPDT', 'stop_date'),
-        ('IMGID', 'img_id'),
     ]
 
     @mapping
+    def relation_id(self, record):
+        binder = self.binder_for('carepoint.fdb.img.id')
+        relation_id = binder.to_odoo(record['IMGUNIQID'])
+        return {'relation_id': relation_id}
+
+    @mapping
+    def image_id(self, record):
+        binder = self.binder_for('carepoint.fdb.img')
+        img_id = binder.to_odoo(record['IMGID'])
+        return {'image_id': img_id}
+
+    @mapping
     def carepoint_id(self, record):
-        return {'carepoint_id': record['IMGUNIQID']}
+        return {'carepoint_id': '%s,%s' % (record['IMGUNIQID'],
+                                           record['IMGSTRTDT'],
+                                           )}
 
 
 @carepoint
 class FdbImgDateImporter(CarepointImporter):
     _model_name = ['carepoint.fdb.img.date']
     _base_mapper = FdbImgDateImportMapper
+
+    def _import_dependencies(self):
+        """ It imports depends for record """
+        self._import_dependency(self.carepoint_record['IMGUNIQID'],
+                                'carepoint.fdb.img.id')
+        self._import_dependency(self.carepoint_record['IMGID'],
+                                'carepoint.fdb.img')

--- a/connector_carepoint/models/fdb_img_id.py
+++ b/connector_carepoint/models/fdb_img_id.py
@@ -4,7 +4,9 @@
 
 import logging
 from openerp import models, fields
+from openerp.addons.connector.connector import ConnectorUnit
 from openerp.addons.connector.unit.mapper import (mapping,
+                                                  only_create,
                                                   )
 from ..unit.backend_adapter import CarepointCRUDAdapter
 from ..unit.mapper import CarepointImportMapper
@@ -12,6 +14,9 @@ from ..backend import carepoint
 from ..unit.import_synchronizer import (DelayedBatchImporter,
                                         CarepointImporter,
                                         )
+
+from .fdb_img_date import FdbImgDateUnit
+
 
 _logger = logging.getLogger(__name__)
 
@@ -21,7 +26,7 @@ class CarepointFdbImgId(models.Model):
     _inherit = 'carepoint.binding'
     _inherits = {'fdb.img.id': 'odoo_id'}
     _description = 'Carepoint FdbImgId'
-    _cp_lib = 'fdb_img_id'  # Name of model in Carepoint lib (snake_case)
+    _cp_lib = 'fdb_img_id'
 
     odoo_id = fields.Many2one(
         string='FdbImgId',
@@ -47,6 +52,21 @@ class FdbImgIdAdapter(CarepointCRUDAdapter):
 
 
 @carepoint
+class FdbImgIdUnit(ConnectorUnit):
+    _model_name = 'carepoint.fdb.img.id'
+
+    def _import_by_ndc(self, ndc):
+        """ It should search for records w/ ndc and import
+        Params:
+            ndc: :type:str NDC to seartch for
+        """
+        adapter = self.unit_for(FdbImgIdAdapter)
+        importer = self.unit_for(FdbImgIdImporter)
+        for record in adapter.search(IMGNDC=ndc):
+            importer.run(record)
+
+
+@carepoint
 class FdbImgIdBatchImporter(DelayedBatchImporter):
     """ Import the Carepoint FdbImgIds.
     For every product category in the list, a delayed job is created.
@@ -58,11 +78,24 @@ class FdbImgIdBatchImporter(DelayedBatchImporter):
 @carepoint
 class FdbImgIdImportMapper(CarepointImportMapper):
     _model_name = 'carepoint.fdb.img.id'
+
     direct = [
         ('IMGDFID', 'df_id'),
-        ('IMGNDC', 'ndc'),
-        ('IMGMFGID', 'mfg_id'),
     ]
+
+    @mapping
+    @only_create
+    def ndc_id(self, record):
+        binder = self.binder_for('carepoint.fdb.ndc')
+        ndc_id = binder.to_odoo(record['IMGNDC'].strip())
+        return {'ndc_id': ndc_id}
+
+    @mapping
+    @only_create
+    def manufacturer_id(self, record):
+        binder = self.binder_for('carepoint.fdb.img.mfg')
+        mfg_id = binder.to_odoo(record['IMGMFGID'])
+        return {'manufacturer_id': mfg_id}
 
     @mapping
     def carepoint_id(self, record):
@@ -73,3 +106,20 @@ class FdbImgIdImportMapper(CarepointImportMapper):
 class FdbImgIdImporter(CarepointImporter):
     _model_name = ['carepoint.fdb.img.id']
     _base_mapper = FdbImgIdImportMapper
+
+    def _import_dependencies(self):
+        """ Import depends for record """
+        record = self.carepoint_record
+        self._import_dependency(record['IMGNDC'].strip(),
+                                'carepoint.fdb.ndc')
+        self._import_dependency(record['IMGMFGID'],
+                                'carepoint.fdb.img.mfg')
+
+    def _after_import(self, binding):
+        img_unit = self.unit_for(
+            FdbImgDateUnit,
+            model='carepoint.fdb.img.date',
+        )
+        img_unit._import_by_unique_id(
+            self.carepoint_record['IMGUNIQID'],
+        )

--- a/connector_carepoint/models/fdb_ndc.py
+++ b/connector_carepoint/models/fdb_ndc.py
@@ -18,6 +18,9 @@ from .fdb_unit import ureg
 from psycopg2 import IntegrityError
 from openerp.exceptions import ValidationError
 
+from .fdb_img_id import FdbImgIdUnit
+
+
 _logger = logging.getLogger(__name__)
 
 
@@ -290,6 +293,12 @@ class FdbNdcImportMapper(CarepointImportMapper):
         return {'medicament_id': medicament_id[0].id}
 
     @mapping
+    def lbl_mfg_id(self, record):
+        binder = self.binder_for('carepoint.fdb.lbl.rid')
+        lbl_rid = binder.to_odoo(record['lblrid'].strip())
+        return {'lbl_mfg_id': lbl_rid}
+
+    @mapping
     def carepoint_id(self, record):
         return {'carepoint_id': record['ndc'].strip()}
 
@@ -310,3 +319,12 @@ class FdbNdcImporter(CarepointImporter):
             pass
         self._import_dependency(record['gcn_seqno'],
                                 'carepoint.fdb.gcn')
+
+    def _after_import(self, binding):
+        img_unit = self.unit_for(
+            FdbImgIdUnit,
+            model='carepoint.fdb.img.id',
+        )
+        img_unit._import_by_ndc(
+            self.carepoint_record['ndc'].strip(),
+        )

--- a/connector_carepoint/tests/models/__init__.py
+++ b/connector_carepoint/tests/models/__init__.py
@@ -24,3 +24,8 @@ from . import test_medical_patient
 
 from . import test_medical_pathology
 from . import test_medical_pathology_type_code
+
+from . import test_fdb_img
+from . import test_fdb_img_date
+from . import test_fdb_img_mfg
+from . import test_fdb_img_id

--- a/connector_carepoint/tests/models/test_fdb_img.py
+++ b/connector_carepoint/tests/models/test_fdb_img.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.connector_carepoint.models import fdb_img
+
+from ..common import SetUpCarepointBase
+
+
+model = 'openerp.addons.connector_carepoint.models.fdb_img'
+
+
+class EndTestException(Exception):
+    pass
+
+
+class FdbImgTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(FdbImgTestBase, self).setUp()
+        self.model = 'carepoint.fdb.img'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+
+    @property
+    def record(self):
+        """ Model record fixture """
+        return {
+            'data': 'I am data'.encode('base64'),
+            'IMGID': 123,
+            'IMGFILENM': 'filename',
+            'IMAGE_PATH': '/this/is/a/path.jpg',
+        }
+
+
+class TestFdbImgImportMapper(FdbImgTestBase):
+
+    def setUp(self):
+        super(TestFdbImgImportMapper, self).setUp()
+        self.Unit = fdb_img.FdbImgImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        expect = {'carepoint_id': self.record['IMGID']}
+        res = self.unit.carepoint_id(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_datas(self):
+        """ It should return correct attribute """
+        expect = {'datas': self.record['data']}
+        res = self.unit.datas(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_mimetype(self):
+        """ It should return correct attribute """
+        expect = {'mimetype': 'image/jpeg'}
+        res = self.unit.mimetype(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_type(self):
+        """ It should return correct attribute """
+        expect = {'type': 'binary'}
+        res = self.unit.type(self.record)
+        self.assertDictEqual(expect, res)
+
+
+class TestFdbImgImporter(FdbImgTestBase):
+
+    def setUp(self):
+        super(TestFdbImgImporter, self).setUp()
+        self.Unit = fdb_img.FdbImgImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_get_carepoint_data_read_image(self):
+        """ It should obtain image from remote Carepoint server """
+        with self.mock_adapter(self.unit):
+            self.unit._get_carepoint_data()
+            read = self.unit.backend_adapter.read_image
+            read.assert_called_once_with(
+                self.unit.backend_adapter.read()['IMAGE_PATH'],
+            )
+
+    def test_get_carepoint_data_return(self):
+        """ It should return result of image read from server """
+        with self.mock_adapter(self.unit):
+            res = self.unit._get_carepoint_data()
+            self.assertEqual(
+                self.unit.backend_adapter.read_image(),
+                res.data,
+            )

--- a/connector_carepoint/tests/models/test_fdb_img_date.py
+++ b/connector_carepoint/tests/models/test_fdb_img_date.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import (
+    fdb_img_date
+)
+
+from ..common import SetUpCarepointBase
+
+
+model = 'openerp.addons.connector_carepoint.models.%s' % (
+    'fdb_img_date'
+)
+
+
+class EndTestException(Exception):
+    pass
+
+
+class FdbImgDateTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(FdbImgDateTestBase, self).setUp()
+        self.model = 'carepoint.fdb.img.date'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+
+    @property
+    def record(self):
+        """ Model record fixture """
+        return {
+            'IMGUNIQID': 1,
+            'IMGID': 2,
+            'IMGSTRTDT': '2016-01-01',
+        }
+
+
+class TestFdbImgDateImportMapper(FdbImgDateTestBase):
+
+    def setUp(self):
+        super(TestFdbImgDateImportMapper, self).setUp()
+        self.Unit = fdb_img_date.FdbImgDateImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        expect = {'carepoint_id': '%s,%s' % (self.record['IMGUNIQID'],
+                                             self.record['IMGSTRTDT'],
+                                             )}
+        res = self.unit.carepoint_id(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_image_id_get_binder(self):
+        """ It should get binder for record type """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.image_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.fdb.img'
+            )
+
+    def test_image_id_to_odoo(self):
+        """ It should get Odoo record for binding """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.image_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['IMGID'],
+            )
+
+    def test_image_id_return(self):
+        """ It should return proper vals dict """
+        with mock.patch.object(self.unit, 'binder_for'):
+            image_id = self.unit.binder_for().to_odoo()
+            expect = {'image_id': image_id}
+            res = self.unit.image_id(self.record)
+            self.assertDictEqual(expect, res)
+
+    def test_relation_id_get_binder(self):
+        """ It should get binder for record type """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.relation_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.fdb.img.id'
+            )
+
+    def test_relation_id_to_odoo(self):
+        """ It should get Odoo record for binding """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.relation_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['IMGUNIQID'],
+            )
+
+    def test_relation_id_return(self):
+        """ It should return proper vals dict """
+        with mock.patch.object(self.unit, 'binder_for'):
+            relation_id = self.unit.binder_for().to_odoo()
+            expect = {'relation_id': relation_id}
+            res = self.unit.relation_id(self.record)
+            self.assertDictEqual(expect, res)
+
+
+class TestFdbImgDateUnit(FdbImgDateTestBase):
+
+    def setUp(self):
+        super(TestFdbImgDateUnit, self).setUp()
+        self.Unit = fdb_img_date.FdbImgDateUnit
+        self.unit = self.Unit(self.mock_env)
+
+    def test_import_by_unique_id_unit_for(self):
+        """ It should get unit for adapter """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            self.unit._import_by_unique_id(True)
+            mk.assert_has_calls([
+                mock.call(fdb_img_date.FdbImgDateAdapter),
+                mock.call(fdb_img_date.FdbImgDateImporter),
+            ])
+
+    def test_import_by_unique_id_search(self):
+        """ It should search for appropriate records """
+        expect = 'expect'
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit._import_by_unique_id(expect)
+            mk().search.assert_called_with(IMGUNIQID=expect)
+
+    def test_import_by_unique_id_import(self):
+        """ It should import the records """
+        expect = mock.MagicMock()
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.return_value = [expect]
+            self.unit._import_by_unique_id(True)
+            mk().run.assert_called_once_with(expect)
+
+
+class TestFdbImgDateImporter(FdbImgDateTestBase):
+
+    def setUp(self):
+        super(TestFdbImgDateImporter, self).setUp()
+        self.Unit = fdb_img_date.\
+            FdbImgDateImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_import_dependencies(self):
+        """ It should import all depedencies """
+        with mock.patch.object(self.unit, '_import_dependency') as mk:
+            self.unit._import_dependencies()
+            mk.assert_has_calls([
+                mock.call(
+                    self.record['IMGUNIQID'],
+                    'carepoint.fdb.img.id',
+                ),
+                mock.call(
+                    self.record['IMGID'],
+                    'carepoint.fdb.img',
+                ),
+            ])

--- a/connector_carepoint/tests/models/test_fdb_img_id.py
+++ b/connector_carepoint/tests/models/test_fdb_img_id.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import (
+    fdb_img_id
+)
+
+from ..common import SetUpCarepointBase
+
+
+model = 'openerp.addons.connector_carepoint.models.%s' % (
+    'fdb_img_id'
+)
+
+
+class EndTestException(Exception):
+    pass
+
+
+class FdbImgIdTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(FdbImgIdTestBase, self).setUp()
+        self.model = 'carepoint.fdb.img.id'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+
+    @property
+    def record(self):
+        """ Model record fixture """
+        return {
+            'IMGUNIQID': 1,
+            'IMGMFGID': 2,
+            'IMGNDC': ' ndc ',
+        }
+
+
+class TestFdbImgIdImportMapper(FdbImgIdTestBase):
+
+    def setUp(self):
+        super(TestFdbImgIdImportMapper, self).setUp()
+        self.Unit = fdb_img_id.FdbImgIdImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        expect = {'carepoint_id': self.record['IMGUNIQID']}
+        res = self.unit.carepoint_id(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_ndc_id_get_binder(self):
+        """ It should get binder for record type """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.ndc_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.fdb.ndc'
+            )
+
+    def test_ndc_id_to_odoo(self):
+        """ It should get Odoo record for binding """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.ndc_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['IMGNDC'].strip(),
+            )
+
+    def test_ndc_id_return(self):
+        """ It should return proper vals dict """
+        with mock.patch.object(self.unit, 'binder_for'):
+            ndc_id = self.unit.binder_for().to_odoo()
+            expect = {'ndc_id': ndc_id}
+            res = self.unit.ndc_id(self.record)
+            self.assertDictEqual(expect, res)
+
+    def test_manufacturer_id_get_binder(self):
+        """ It should get binder for record type """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.manufacturer_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.fdb.img.mfg'
+            )
+
+    def test_manufacturer_id_to_odoo(self):
+        """ It should get Odoo record for binding """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.manufacturer_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['IMGMFGID'],
+            )
+
+    def test_manufacturer_id_return(self):
+        """ It should return proper vals dict """
+        with mock.patch.object(self.unit, 'binder_for'):
+            manufacturer_id = self.unit.binder_for().to_odoo()
+            expect = {'manufacturer_id': manufacturer_id}
+            res = self.unit.manufacturer_id(self.record)
+            self.assertDictEqual(expect, res)
+
+
+class TestFdbImgIdUnit(FdbImgIdTestBase):
+
+    def setUp(self):
+        super(TestFdbImgIdUnit, self).setUp()
+        self.Unit = fdb_img_id.FdbImgIdUnit
+        self.unit = self.Unit(self.mock_env)
+
+    def test_import_by_ndc_unit_for(self):
+        """ It should get unit for adapter """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            self.unit._import_by_ndc(True)
+            mk.assert_has_calls([
+                mock.call(fdb_img_id.FdbImgIdAdapter),
+                mock.call(fdb_img_id.FdbImgIdImporter),
+            ])
+
+    def test_import_by_ndc_search(self):
+        """ It should search for appropriate records """
+        expect = 'expect'
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit._import_by_ndc(expect)
+            mk().search.assert_called_with(IMGNDC=expect)
+
+    def test_import_by_ndc_import(self):
+        """ It should import the records """
+        expect = mock.MagicMock()
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.return_value = [expect]
+            self.unit._import_by_ndc(True)
+            mk().run.assert_called_once_with(expect)
+
+
+class TestFdbImgIdImporter(FdbImgIdTestBase):
+
+    def setUp(self):
+        super(TestFdbImgIdImporter, self).setUp()
+        self.Unit = fdb_img_id.\
+            FdbImgIdImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_import_dependencies(self):
+        """ It should import all depedencies """
+        with mock.patch.object(self.unit, '_import_dependency') as mk:
+            self.unit._import_dependencies()
+            mk.assert_has_calls([
+                mock.call(
+                    self.record['IMGNDC'].strip(),
+                    'carepoint.fdb.ndc',
+                ),
+                mock.call(
+                    self.record['IMGMFGID'],
+                    'carepoint.fdb.img.mfg',
+                ),
+            ])
+
+    def test_after_import_unit(self):
+        """ It should get proper unit """
+        with mock.patch.object(self.unit, 'unit_for'):
+            self.unit._after_import(None)
+            self.unit.unit_for.assert_called_once_with(
+                fdb_img_id.FdbImgDateUnit,
+                model='carepoint.fdb.img.date',
+            )
+
+    def test_after_import_import(self):
+        """ It should run import method on unit """
+        with mock.patch.object(self.unit, 'unit_for'):
+            self.unit._after_import(None)
+            self.unit.unit_for()._import_by_unique_id.assert_called_once_with(
+                self.record['IMGUNIQID'],
+            )

--- a/connector_carepoint/tests/models/test_fdb_img_mfg.py
+++ b/connector_carepoint/tests/models/test_fdb_img_mfg.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import fdb_img_mfg
+
+from ..common import SetUpCarepointBase
+
+
+model = 'openerp.addons.connector_carepoint.models.fdb_img'
+
+
+class EndTestException(Exception):
+    pass
+
+
+class FdbImgMfgTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(FdbImgMfgTestBase, self).setUp()
+        self.model = 'carepoint.fdb.img.mfg'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+
+    @property
+    def record(self):
+        """ Model record fixture """
+        return {
+            'IMGMFGID': 123,
+            'IMGMFGNAME': ' Image Name ',
+        }
+
+
+class TestFdbImgMfgImportMapper(FdbImgMfgTestBase):
+
+    def setUp(self):
+        super(TestFdbImgMfgImportMapper, self).setUp()
+        self.Unit = fdb_img_mfg.FdbImgMfgImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        expect = {'carepoint_id': self.record['IMGMFGID']}
+        res = self.unit.carepoint_id(self.record)
+        self.assertDictEqual(expect, res)
+
+    def test_manufacturer_id_search(self):
+        """ It should search for manufacturer w/ proper args """
+        with mock.patch.object(self.unit.session, 'env') as env:
+            self.unit.manufacturer_id(self.record)
+            env[''].search.assert_called_once_with(
+                [('name', 'ilike', self.record['IMGMFGNAME'].strip())],
+                limit=1,
+            )
+
+    def test_manufacturer_id_return(self):
+        """ It should return result of search if any """
+        expect = mock.MagicMock()
+        with mock.patch.object(self.unit.session, 'env') as env:
+            env[''].search.return_value = [expect]
+            res = self.unit.manufacturer_id(self.record)
+            self.assertDictEqual(
+                {'manufacturer_id': expect.id},
+                res,
+            )

--- a/connector_carepoint/unit/backend_adapter.py
+++ b/connector_carepoint/unit/backend_adapter.py
@@ -85,7 +85,7 @@ class CarepointCRUDAdapter(CRUDAdapter):
             path: :type:`str` SMB path of image
 
         Returns:
-            :type:`str` Binary string representation of file
+            :type:`str` Base64 encoded binary file
         """
         return self.carepoint.get_file(path).read().encode('base64')
 

--- a/first_databank/models/fdb_img.py
+++ b/first_databank/models/fdb_img.py
@@ -7,8 +7,16 @@ from openerp import models, fields
 
 class FdbImg(models.Model):
     _name = 'fdb.img'
+    _inherits = {'ir.attachment': 'attachment_id'}
     _description = 'Fdb Img'
-    file_name = fields.Char()
-    data = fields.Binary(
-        attachment=True,
+    attachment_id = fields.Many2one(
+        string='Attachment',
+        comodel_name='ir.attachment',
+        required=True,
+        ondelete='cascade',
+    )
+    image_date_ids = fields.One2many(
+        string='Image Dates',
+        comodel_name='fdb.img.date',
+        inverse_name='image_id',
     )

--- a/first_databank/models/fdb_img_date.py
+++ b/first_databank/models/fdb_img_date.py
@@ -2,12 +2,41 @@
 # © 2015-TODAY LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields
+from datetime import datetime
+
+from openerp import models, fields, api
 
 
 class FdbImgDate(models.Model):
     _name = 'fdb.img.date'
     _description = 'Fdb Img Date'
-    start_date = fields.Datetime()
+    _inherits = {'fdb.img': 'image_id'}
+
+    start_date = fields.Datetime(
+        required=True,
+    )
     stop_date = fields.Datetime()
-    img_id = fields.Integer()
+    image_id = fields.Many2one(
+        string='Image',
+        comodel_name='fdb.img',
+        required=True,
+        ondelete='restrict',
+    )
+    active = fields.Boolean(
+        compute='_compute_active',
+    )
+    relation_id = fields.Many2one(
+        string='Relation',
+        comodel_name='fdb.img.id',
+        inverse_name='relation_id',
+    )
+
+    @api.multi
+    def _compute_active(self):
+        """ It sets active to false if stop_date < today """
+        for rec_id in self:
+            if not rec_id.stop_date:
+                pass
+            stop_date = fields.Datetime.from_string(rec_id.stop_date)
+            if stop_date < datetime.now():
+                rec_id.active = False

--- a/first_databank/models/fdb_img_id.py
+++ b/first_databank/models/fdb_img_id.py
@@ -7,6 +7,19 @@ from openerp import models, fields
 
 class FdbImgId(models.Model):
     _name = 'fdb.img.id'
-    df_id = fields.Integer()
-    ndc = fields.Char()
-    mfg_id = fields.Integer()
+    df_id = fields.Integer(
+        help='This is an unidentified relation',
+    )
+    ndc_id = fields.Many2one(
+        string='FDB NDC',
+        comodel_name='fdb.ndc',
+    )
+    manufacturer_id = fields.Many2one(
+        string='Image Manufacturer',
+        comodel_name='fdb.img.mfg',
+    )
+    image_ids = fields.One2many(
+        string='Images',
+        comodel_name='fdb.img.date',
+        inverse_name='relation_id',
+    )

--- a/first_databank/models/fdb_ndc.py
+++ b/first_databank/models/fdb_ndc.py
@@ -16,6 +16,10 @@ class FdbNdc(models.Model):
         ondelete='cascade',
         required=True,
     )
+    lbl_mfg_id = fields.Many2one(
+        string='Label Manufacturer',
+        comodel_name='fdb.lbl.rid',
+    )
     lblrid = fields.Char()
     gcn_seqno = fields.Char()
     ps = fields.Char()


### PR DESCRIPTION
Two modules changed:

[IMP] first_databank: Upgrade FDB Image integration
- Polymorphic inherits on `fdb.img` w/ `ir_attachment`
- Add relations between fdb image models

[IMP] connector_carepoint: Add FDB Image import
- Update importers for proper sync and inheritance logic
- Improve test coverage
