### PR TITLE
[9.0][ADD] connector_carepoint: Implement pathology and codes

### DIFF
--- a/connector_carepoint/models/__init__.py
+++ b/connector_carepoint/models/__init__.py
@@ -19,6 +19,8 @@ from . import medical_patient
 from . import medical_physician
 from . import medical_prescription_order
 from . import medical_prescription_order_line
+from . import medical_pathology
+from . import medical_pathology_code_type
 
 # Address / Relations
 from . import address

--- a/connector_carepoint/models/medical_pathology.py
+++ b/connector_carepoint/models/medical_pathology.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+from openerp import models, fields
+from openerp.addons.connector.connector import ConnectorUnit
+from openerp.addons.connector.unit.mapper import (mapping,
+                                                  only_create,
+                                                  )
+from ..unit.backend_adapter import CarepointCRUDAdapter
+from ..backend import carepoint
+from ..unit.mapper import PartnerImportMapper, trim
+from ..unit.import_synchronizer import (DelayedBatchImporter,
+                                        CarepointImporter,
+                                        )
+
+from ..connector import add_checkpoint
+
+
+_logger = logging.getLogger(__name__)
+
+
+class CarepointMedicalPathology(models.Model):
+    """ Binding Model for the Carepoint Store """
+    _name = 'carepoint.medical.pathology'
+    _inherit = 'carepoint.binding'
+    _inherits = {'medical.pathology': 'odoo_id'}
+    _description = 'Carepoint Pathologies'
+    _cp_lib = 'pathology'
+
+    odoo_id = fields.Many2one(
+        comodel_name='medical.pathology',
+        string='Company',
+        required=True,
+        ondelete='cascade'
+    )
+
+
+class MedicalPathology(models.Model):
+    """ Adds the ``one2many`` relation to the Carepoint bindings
+    (``carepoint_bind_ids``)
+    """
+    _inherit = 'medical.pathology'
+
+    carepoint_bind_ids = fields.One2many(
+        comodel_name='carepoint.medical.pathology',
+        inverse_name='odoo_id',
+        string='Carepoint Bindings',
+    )
+
+
+@carepoint
+class MedicalPathologyAdapter(CarepointCRUDAdapter):
+    """ Backend Adapter for the Carepoint Store """
+    _model_name = 'carepoint.medical.pathology'
+
+
+@carepoint
+class MedicalPathologyBatchImporter(DelayedBatchImporter):
+    """ Import the Carepoint Stores.
+    For every company in the list, a delayed job is created.
+    """
+    _model_name = ['carepoint.medical.pathology']
+
+
+@carepoint
+class MedicalPathologyUnit(ConnectorUnit):
+    _model_name = 'carepoint.medical.pathology'
+
+    def _import_by_code(self, code):
+        adapter = self.unit_for(MedicalPathologyAdapter)
+        importer = self.unit_for(MedicalPathologyImporter)
+        for record in adapter.search(icd_cd=code):
+            importer.run(record)
+
+
+@carepoint
+class MedicalPathologyImportMapper(PartnerImportMapper):
+    _model_name = 'carepoint.medical.pathology'
+
+    direct = [
+        (trim('icd_cd'), 'code'),
+        (trim('icd_desc'), 'name'),
+    ]
+
+    @mapping
+    @only_create
+    def odoo_id(self, record):
+        """ Will bind the record on an existing record with the same name """
+        code_type = self.code_type_id(record)
+        record = self.env['medical.pathology'].search([
+            ('code_type_id', '=', code_type['code_type_id']),
+            ('code', '=', record['icd_cd'].strip()),
+        ],
+            limit=1,
+        )
+        if record:
+            return {'odoo_id': record.id}
+
+    @mapping
+    def code_type_id(self, record):
+        binder = self.binder_for('carepoint.medical.pathology.code.type')
+        type_id = binder.to_odoo(record['icd_cd_type'].strip())
+        return {'code_type_id': type_id}
+
+    @mapping
+    def carepoint_id(self, record):
+        return {'carepoint_id': '%s,%s' % (record['icd_cd'].strip(),
+                                           record['icd_cd_type'].strip(),
+                                           )}
+
+
+@carepoint
+class MedicalPathologyImporter(CarepointImporter):
+    _model_name = ['carepoint.medical.pathology']
+    _base_mapper = MedicalPathologyImportMapper
+
+    def _import_dependencies(self):
+        record = self.carepoint_record
+        self._import_dependency(record['icd_cd_type'].strip(),
+                                'carepoint.medical.pathology.code.type')
+
+    def _create(self, data):   # pragma: no cover
+        binding = super(MedicalPathologyImporter, self)._create(data)
+        add_checkpoint(
+            self.session, binding._name, binding.id, binding.backend_id.id
+        )
+        return binding

--- a/connector_carepoint/models/medical_pathology_code_type.py
+++ b/connector_carepoint/models/medical_pathology_code_type.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+from openerp import models, fields
+from openerp.addons.connector.unit.mapper import (mapping,
+                                                  only_create,
+                                                  )
+from ..unit.backend_adapter import CarepointCRUDAdapter
+from ..backend import carepoint
+from ..unit.mapper import PartnerImportMapper, trim
+from ..unit.import_synchronizer import (DelayedBatchImporter,
+                                        CarepointImporter,
+                                        )
+
+
+_logger = logging.getLogger(__name__)
+
+
+class CarepointMedicalPathologyCodeType(models.Model):
+    """ Binding Model for the Carepoint Store """
+    _name = 'carepoint.medical.pathology.code.type'
+    _inherit = 'carepoint.binding'
+    _inherits = {'medical.pathology.code.type': 'odoo_id'}
+    _description = 'Carepoint Pathology Code Types'
+    _cp_lib = 'pathology_code_type'
+
+    odoo_id = fields.Many2one(
+        comodel_name='medical.pathology.code.type',
+        string='Company',
+        required=True,
+        ondelete='cascade'
+    )
+
+
+class MedicalPathologyCodeType(models.Model):
+    """ Adds the ``one2many`` relation to the Carepoint bindings
+    (``carepoint_bind_ids``)
+    """
+    _inherit = 'medical.pathology.code.type'
+
+    carepoint_bind_ids = fields.One2many(
+        comodel_name='carepoint.medical.pathology.code.type',
+        inverse_name='odoo_id',
+        string='Carepoint Bindings',
+    )
+
+
+@carepoint
+class MedicalPathologyCodeTypeAdapter(CarepointCRUDAdapter):
+    """ Backend Adapter for the Carepoint Store """
+    _model_name = 'carepoint.medical.pathology.code.type'
+
+
+@carepoint
+class MedicalPathologyCodeTypeBatchImporter(DelayedBatchImporter):
+    """ Import the Carepoint Stores.
+    For every company in the list, a delayed job is created.
+    """
+    _model_name = ['carepoint.medical.pathology.code.type']
+
+
+@carepoint
+class MedicalPathologyCodeTypeImportMapper(PartnerImportMapper):
+    _model_name = 'carepoint.medical.pathology.code.type'
+
+    direct = [
+        (trim('icd_cd_type_desc'), 'name'),
+    ]
+
+    @mapping
+    @only_create
+    def odoo_id(self, record):
+        """ Will bind the record on an existing record with the same name """
+        record = self.env['medical.pathology.code.type'].search(
+            [('name', 'ilike', record['icd_cd_type_desc'].strip())],
+            limit=1,
+        )
+        if record:
+            return {'odoo_id': record.id}
+
+    @mapping
+    def carepoint_id(self, record):
+        return {'carepoint_id': record['icd_cd_type']}
+
+
+@carepoint
+class MedicalPathologyCodeTypeImporter(CarepointImporter):
+    _model_name = ['carepoint.medical.pathology.code.type']
+    _base_mapper = MedicalPathologyCodeTypeImportMapper

--- a/connector_carepoint/tests/models/__init__.py
+++ b/connector_carepoint/tests/models/__init__.py
@@ -21,3 +21,6 @@ from . import test_address_store
 from . import test_address_organization
 from . import test_address_physician
 from . import test_medical_patient
+
+from . import test_medical_pathology
+from . import test_medical_pathology_type_code

--- a/connector_carepoint/tests/models/test_medical_pathology.py
+++ b/connector_carepoint/tests/models/test_medical_pathology.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import medical_pathology
+
+from ..common import SetUpCarepointBase
+
+
+class EndTestException(Exception):
+    pass
+
+
+class MedicalPathologyTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(MedicalPathologyTestBase, self).setUp()
+        self.model = 'carepoint.medical.pathology'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+        self.record = {
+            'icd_cd': ' ICD Code ',
+            'icd_cd_type': ' ICD Type Code ',
+        }
+
+
+class TestMedicalPathologyImportMapper(MedicalPathologyTestBase):
+
+    def setUp(self):
+        super(TestMedicalPathologyImportMapper, self).setUp()
+        self.Unit = medical_pathology.MedicalPathologyImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_odoo_id(self):
+        """ It should return odoo_id of recs with same code & type """
+        with mock.patch.object(self.unit, 'binder_for'):
+            model_obj = self.env['carepoint.medical.pathology.code.type']
+            code_type_id = model_obj.create({
+                'name': self.record['icd_cd_type'].strip(),
+            })
+            self.unit.binder_for().to_odoo.return_value = code_type_id.id
+            expect = self.env['medical.pathology'].create({
+                'name': 'Pathology',
+                'code_type_id': code_type_id.id,
+                'code': self.record['icd_cd'].strip(),
+            })
+            res = self.unit.odoo_id(self.record)
+            expect = {'odoo_id': expect.id}
+            self.assertDictEqual(expect, res)
+
+    def test_code_type_id_get_binder(self):
+        """ It should get binder for prescription line """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.code_type_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.medical.pathology.code.type'
+            )
+
+    def test_code_type_id_to_odoo(self):
+        """ It should get Odoo record for rx """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.code_type_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['icd_cd_type'].strip(),
+            )
+
+    def test_code_type_id_return(self):
+        """ It should return formatted code_type_id """
+        with mock.patch.object(self.unit, 'binder_for'):
+            res = self.unit.code_type_id(self.record)
+            expect = self.unit.binder_for().to_odoo()
+            self.assertDictEqual({'code_type_id': expect}, res)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        res = self.unit.carepoint_id(self.record)
+        expect = {
+            'carepoint_id': '%s,%s' % (
+                self.record['icd_cd'].strip(),
+                self.record['icd_cd_type'].strip(),
+            ),
+        }
+        self.assertDictEqual(expect, res)
+
+
+class TestMedicalPathologyUnit(MedicalPathologyTestBase):
+
+    def setUp(self):
+        super(TestMedicalPathologyUnit, self).setUp()
+        self.Unit = medical_pathology.MedicalPathologyUnit
+        self.unit = self.Unit(self.mock_env)
+
+    def test_import_by_code_unit_for_adapter(self):
+        """ It should get unit for adapter """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            self.unit._import_by_code(True)
+            mk.assert_has_calls([
+                mock.call(
+                    medical_pathology.MedicalPathologyAdapter,
+                ),
+                mock.call(
+                    medical_pathology.MedicalPathologyImporter,
+                ),
+            ])
+
+    def test_import_by_code_search(self):
+        """ It should search adapter for unit """
+        expect = 'expect'
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit._import_by_code(expect)
+            mk().search.assert_called_once_with(
+                icd_cd=expect,
+            )
+
+    def test_import_by_code_imports(self):
+        """ It should run importer on records """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            expect = mock.MagicMock()
+            adapter = mock.MagicMock()
+            adapter.search.return_value = [True]
+            mk.side_effect = [adapter, expect]
+            self.unit._import_by_code(True)
+            expect.run.assert_called_once_with(
+                adapter.search()[0]
+            )
+
+
+class TestMedicalPathologyImporter(MedicalPathologyTestBase):
+
+    def setUp(self):
+        super(TestMedicalPathologyImporter, self).setUp()
+        self.Unit = medical_pathology.MedicalPathologyImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_after_import_dependencies(self):
+        """ It should import all depedencies """
+        with mock.patch.object(self.unit, '_import_dependency') as mk:
+            self.unit._import_dependencies()
+            mk.assert_has_calls([
+                mock.call(
+                    self.record['icd_cd_type'].strip(),
+                    'carepoint.medical.pathology.code.type',
+                ),
+            ])

--- a/connector_carepoint/tests/models/test_medical_pathology_type_code.py
+++ b/connector_carepoint/tests/models/test_medical_pathology_type_code.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.connector_carepoint.models import (
+    medical_pathology_code_type,
+)
+
+from ..common import SetUpCarepointBase
+
+
+class EndTestException(Exception):
+    pass
+
+
+class MedicalPathologyCodeTypeTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(MedicalPathologyCodeTypeTestBase, self).setUp()
+        self.model = 'carepoint.medical.pathology.code.type'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+        self.record = {
+            'icd_cd_type': ' ICD Type Code ',
+            'icd_cd_type_desc': ' ICD Type Desc ',
+        }
+
+
+class TestMedicalPathologyCodeTypeImportMapper(
+    MedicalPathologyCodeTypeTestBase
+):
+
+    def setUp(self):
+        super(TestMedicalPathologyCodeTypeImportMapper, self).setUp()
+        self.Unit = \
+            medical_pathology_code_type.MedicalPathologyCodeTypeImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_odoo_id(self):
+        """ It should return odoo_id of pharmacies with same name """
+        model = self.env['medical.pathology.code.type']
+        expect = model.create({
+            'name': self.record['icd_cd_type_desc'].strip(),
+        })
+        res = self.unit.odoo_id(self.record)
+        expect = {'odoo_id': expect.id}
+        self.assertDictEqual(expect, res)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        res = self.unit.carepoint_id(self.record)
+        expect = {
+            'carepoint_id': self.record['icd_cd_type'],
+        }
+        self.assertDictEqual(expect, res)


### PR DESCRIPTION
- Add `medical.pathology` bindings and import
- Add `medical.pathology.code.type` bindings and import

Dependent on:
- [x] LasLabs/vertical-medical#8
