### PR TITLE
[9.0]	[ADD] connector_carepoint: Implement patient disease import

### DIFF
--- a/connector_carepoint/models/__init__.py
+++ b/connector_carepoint/models/__init__.py
@@ -21,6 +21,7 @@ from . import medical_prescription_order
 from . import medical_prescription_order_line
 from . import medical_pathology
 from . import medical_pathology_code_type
+from . import medical_patient_disease
 
 # Address / Relations
 from . import address

--- a/connector_carepoint/models/medical_patient.py
+++ b/connector_carepoint/models/medical_patient.py
@@ -21,6 +21,7 @@ from ..unit.export_synchronizer import CarepointExporter
 
 from .address_patient import CarepointAddressPatientUnit
 from .carepoint_account import CarepointAccountUnit
+from .medical_patient_disease import MedicalPatientDiseaseUnit
 
 _logger = logging.getLogger(__name__)
 
@@ -122,6 +123,9 @@ class MedicalPatientImporter(CarepointImporter):
         account = self.unit_for(CarepointAccountUnit,
                                 model='carepoint.carepoint.account')
         account._import_accounts(self.carepoint_id)
+        disease = self.unit_for(MedicalPatientDiseaseUnit,
+                                model='carepoint.medical.patient.disease')
+        disease._import_by_patient(self.carepoint_id)
 
 
 @carepoint

--- a/connector_carepoint/models/medical_patient_disease.py
+++ b/connector_carepoint/models/medical_patient_disease.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+from openerp import models, fields
+from openerp.addons.connector.connector import ConnectorUnit
+from openerp.addons.connector.unit.mapper import (mapping,
+                                                  only_create,
+                                                  )
+from ..unit.backend_adapter import CarepointCRUDAdapter
+from ..backend import carepoint
+from ..unit.mapper import PartnerImportMapper
+from ..unit.import_synchronizer import (DelayedBatchImporter,
+                                        CarepointImporter,
+                                        )
+
+from .medical_pathology import MedicalPathologyUnit
+
+
+from ..connector import add_checkpoint
+
+
+_logger = logging.getLogger(__name__)
+
+
+class CarepointMedicalPatientDisease(models.Model):
+    """ Binding Model for the Carepoint Store """
+    _name = 'carepoint.medical.patient.disease'
+    _inherit = 'carepoint.binding'
+    _inherits = {'medical.patient.disease': 'odoo_id'}
+    _description = 'Carepoint Patient Disease'
+    _cp_lib = 'patient_disease'
+
+    odoo_id = fields.Many2one(
+        comodel_name='medical.patient.disease',
+        string='Company',
+        required=True,
+        ondelete='cascade'
+    )
+
+
+class MedicalPatientDisease(models.Model):
+    """ Adds the ``one2many`` relation to the Carepoint bindings
+    (``carepoint_bind_ids``)
+    """
+    _inherit = 'medical.patient.disease'
+
+    carepoint_bind_ids = fields.One2many(
+        comodel_name='carepoint.medical.patient.disease',
+        inverse_name='odoo_id',
+        string='Carepoint Bindings',
+    )
+
+
+@carepoint
+class MedicalPatientDiseaseAdapter(CarepointCRUDAdapter):
+    """ Backend Adapter for the Carepoint Store """
+    _model_name = 'carepoint.medical.patient.disease'
+
+
+@carepoint
+class MedicalPatientDiseaseBatchImporter(DelayedBatchImporter):
+    _model_name = ['carepoint.medical.patient.disease']
+
+
+@carepoint
+class MedicalPatientDiseaseUnit(ConnectorUnit):
+    _model_name = 'carepoint.medical.patient.disease'
+
+    def _import_by_patient(self, carepoint_patient_id):
+        adapter = self.unit_for(MedicalPatientDiseaseAdapter)
+        importer = self.unit_for(MedicalPatientDiseaseImporter)
+        for record in adapter.search(pat_id=carepoint_patient_id):
+            importer.run(record)
+
+
+@carepoint
+class MedicalPatientDiseaseImportMapper(PartnerImportMapper):
+    _model_name = 'carepoint.medical.patient.disease'
+
+    direct = [
+        ('onset_date', 'diagnosed_date'),
+        ('resolution_date', 'healed_date'),
+    ]
+
+    @mapping
+    def pathology_id(self, record):
+        pathology_id = self.env['medical.pathology'].search([
+            ('code', '=', record['icd9'].strip()),
+            ('code_type_id.name', '=ilike', 'ICD9%'),
+        ],
+            limit=1,
+        )
+        return {'pathology_id': pathology_id.id}
+
+    @mapping
+    @only_create
+    def patient_id(self, record):
+        binder = self.binder_for('carepoint.medical.patient')
+        record_id = binder.to_odoo(record['pat_id'])
+        return {'patient_id': record_id}
+
+    @mapping
+    @only_create
+    def physician_id(self, record):
+        binder = self.binder_for('carepoint.medical.physician')
+        record_id = binder.to_odoo(record['caring_md_id'])
+        return {'physician_id': record_id}
+
+    @mapping
+    def carepoint_id(self, record):
+        return {'carepoint_id': record['ptdx_id']}
+
+
+@carepoint
+class MedicalPatientDiseaseImporter(CarepointImporter):
+    _model_name = ['carepoint.medical.patient.disease']
+    _base_mapper = MedicalPatientDiseaseImportMapper
+
+    def _import_dependencies(self):
+        record = self.carepoint_record
+        self._import_dependency(record['pat_id'],
+                                'carepoint.medical.patient')
+        self._import_dependency(record['caring_md_id'],
+                                'carepoint.medical.physician')
+        pathology = self.unit_for(MedicalPathologyUnit,
+                                  'carepoint.medical.pathology')
+        pathology._import_by_code(record['icd9'].strip())
+
+    def _create(self, data):   # pragma: no cover
+        binding = super(MedicalPatientDiseaseImporter, self)._create(data)
+        add_checkpoint(
+            self.session, binding._name, binding.id, binding.backend_id.id
+        )
+        return binding

--- a/connector_carepoint/tests/models/__init__.py
+++ b/connector_carepoint/tests/models/__init__.py
@@ -10,6 +10,7 @@ from . import test_fdb_ndc
 
 from . import test_account_invoice_line
 from . import test_medical_prescription_order_line
+from . import test_medical_patient_disease
 
 from . import test_sale_order_line
 from . import test_sale_order

--- a/connector_carepoint/tests/models/test_medical_patient.py
+++ b/connector_carepoint/tests/models/test_medical_patient.py
@@ -111,6 +111,13 @@ class TestMedicalPatientImporter(MedicalPatientTestBase):
                 mock.call()._import_accounts(
                     self.unit.carepoint_id,
                 ),
+                mock.call(
+                    medical_patient.MedicalPatientDiseaseUnit,
+                    model='carepoint.medical.patient.disease',
+                ),
+                mock.call()._import_by_patient(
+                    self.unit.carepoint_id,
+                ),
             ])
 
 

--- a/connector_carepoint/tests/models/test_medical_patient_disease.py
+++ b/connector_carepoint/tests/models/test_medical_patient_disease.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import medical_patient_disease
+
+from ..common import SetUpCarepointBase
+
+
+class EndTestException(Exception):
+    pass
+
+
+class MedicalPatientDiseaseTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(MedicalPatientDiseaseTestBase, self).setUp()
+        self.model = 'carepoint.medical.patient.disease'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+        self.record = {
+            'pat_id': 1,
+            'caring_md_id': 2,
+            'ptdx_id': 3,
+            'icd9': ' 520.0 ',
+        }
+
+
+class TestMedicalPatientDiseaseImportMapper(MedicalPatientDiseaseTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientDiseaseImportMapper, self).setUp()
+        self.Unit = medical_patient_disease.MedicalPatientDiseaseImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def test_pathology_id(self):
+        """ It should get ICD9 pathology of right code """
+        code_type_id = self.env.ref('medical_pathology.pathology_code_01')
+        expect = self.env['medical.pathology'].create({
+            'name': 'Pathology',
+            'code_type_id': code_type_id.id,
+            'code': self.record['icd9'].strip(),
+        })
+        res = self.unit.pathology_id(self.record)
+        self.assertDictEqual(
+            {'pathology_id': expect.id},
+            res,
+        )
+
+    def test_patient_id_get_binder(self):
+        """ It should get binder for prescription line """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.patient_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.medical.patient'
+            )
+
+    def test_patient_id_to_odoo(self):
+        """ It should get Odoo record for rx """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.patient_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['pat_id'],
+            )
+
+    def test_patient_id_return(self):
+        """ It should return formatted patient_id """
+        with mock.patch.object(self.unit, 'binder_for'):
+            res = self.unit.patient_id(self.record)
+            expect = self.unit.binder_for().to_odoo()
+            self.assertDictEqual({'patient_id': expect}, res)
+
+    def test_physician_id_get_binder(self):
+        """ It should get binder for prescription line """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.physician_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.medical.physician'
+            )
+
+    def test_physician_id_to_odoo(self):
+        """ It should get Odoo record for rx """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_odoo.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.physician_id(self.record)
+            self.unit.binder_for().to_odoo.assert_called_once_with(
+                self.record['caring_md_id'],
+            )
+
+    def test_physician_id_return(self):
+        """ It should return formatted physician_id """
+        with mock.patch.object(self.unit, 'binder_for'):
+            res = self.unit.physician_id(self.record)
+            expect = self.unit.binder_for().to_odoo()
+            self.assertDictEqual({'physician_id': expect}, res)
+
+    def test_carepoint_id(self):
+        """ It should return correct attribute """
+        res = self.unit.carepoint_id(self.record)
+        expect = {
+            'carepoint_id': self.record['ptdx_id'],
+        }
+        self.assertDictEqual(expect, res)
+
+
+class TestMedicalPatientDiseaseUnit(MedicalPatientDiseaseTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientDiseaseUnit, self).setUp()
+        self.Unit = medical_patient_disease.MedicalPatientDiseaseUnit
+        self.unit = self.Unit(self.mock_env)
+
+    def test_import_by_patient_unit_for_adapter(self):
+        """ It should get unit for adapter """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            self.unit._import_by_patient(True)
+            mk.assert_has_calls([
+                mock.call(
+                    medical_patient_disease.MedicalPatientDiseaseAdapter,
+                ),
+                mock.call(
+                    medical_patient_disease.MedicalPatientDiseaseImporter,
+                ),
+            ])
+
+    def test_import_by_patient_search(self):
+        """ It should search adapter for unit """
+        expect = 'expect'
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            mk().search.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit._import_by_patient(expect)
+            mk().search.assert_called_once_with(
+                pat_id=expect,
+            )
+
+    def test_import_by_patient_imports(self):
+        """ It should run importer on records """
+        with mock.patch.object(self.unit, 'unit_for') as mk:
+            expect = mock.MagicMock()
+            adapter = mock.MagicMock()
+            adapter.search.return_value = [True]
+            mk.side_effect = [adapter, expect]
+            self.unit._import_by_patient(True)
+            expect.run.assert_called_once_with(
+                adapter.search()[0]
+            )
+
+
+class TestMedicalPatientDiseaseImporter(MedicalPatientDiseaseTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientDiseaseImporter, self).setUp()
+        self.Unit = medical_patient_disease.MedicalPatientDiseaseImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_after_import_dependencies(self):
+        """ It should import all depedencies """
+        with mock.patch.object(self.unit, '_import_dependency') as mk:
+            with mock.patch.object(self.unit, 'unit_for'):
+                self.unit._import_dependencies()
+                mk.assert_has_calls([
+                    mock.call(
+                        self.record['pat_id'],
+                        'carepoint.medical.patient',
+                    ),
+                    mock.call(
+                        self.record['caring_md_id'],
+                        'carepoint.medical.physician',
+                    ),
+                ])
+
+    def test_after_import_dependencies_pathology_unit(self):
+        """ It should get unit for pathology """
+        with mock.patch.object(self.unit, '_import_dependency'):
+            with mock.patch.object(self.unit, 'unit_for'):
+                self.unit._import_dependencies()
+                self.unit.unit_for.assert_has_calls([
+                    mock.call(
+                        medical_patient_disease.MedicalPathologyUnit,
+                        'carepoint.medical.pathology',
+                    ),
+                    mock.call()._import_by_code(
+                        self.record['icd9'].strip(),
+                    )
+                ])


### PR DESCRIPTION
- Add `medical.patient.disease` bindings and import

Dependent on:
- [x] LasLabs/vertical-medical#8
- [x] #8 
