### PR TITLE
[9.0][ADD] connector_carepoint: Write, Create + Patient Export

### DIFF
--- a/connector_carepoint/consumer.py
+++ b/connector_carepoint/consumer.py
@@ -3,14 +3,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 # from openerp.addons.connector.connector import Binder
-from .unit.export_synchronizer import (export_record,
-                                       )
+from .unit.export_synchronizer import export_record
 # from .unit.delete_synchronizer import export_delete_record
 # from .connector import get_environment
-# from openerp.addons.connector.event import (on_record_write,
-#                                             on_record_create,
-#                                             on_record_unlink
-#                                             )
+from openerp.addons.connector.event import (on_record_write,
+                                            on_record_create,
+                                            # on_record_unlink
+                                            )
 
 
 import logging
@@ -21,10 +20,6 @@ _logger = logging.getLogger(__name__)
 #                                'carepoint.carepoint.address',
 #                                'carepoint.carepoint.address.patient',
 #                                ])
-# @on_record_write(model_names=['carepoint.medical.patient',
-#                               'carepoint.carepoint.address',
-#                               'carepoint.carepoint.address.patient',
-#                               ])
 def delay_export(session, model_name, record_id, vals):
     """ Delay a job which export a binding record.
     (A binding record being a ``carepoint.res.partner``,
@@ -36,10 +31,8 @@ def delay_export(session, model_name, record_id, vals):
     export_record.delay(session, model_name, record_id, fields=fields)
 
 
-# @on_record_write(model_names=['medical.patient',
-#                               'carepoint.address',
-#                               'carepoint.address.patient',
-#                               ])
+@on_record_write(model_names=['carepoint.address',
+                              ])
 def delay_export_all_bindings(session, model_name, record_id, vals):
     """ Delay a job which export all the bindings of a record.
     In this case, it is called on records of normal models and will delay
@@ -52,6 +45,23 @@ def delay_export_all_bindings(session, model_name, record_id, vals):
     for binding in record.carepoint_bind_ids:
         export_record.delay(session, binding._model._name, binding.id,
                             fields=fields)
+
+
+@on_record_create(model_names=['carepoint.address',
+                               ])
+def delay_create(session, model_name, record_id, vals):
+    """ Create a new binding record, then trigger delayed export
+    In this case, it is called on records of normal models to create
+    binding record, and trigger external system export
+    """
+    model_obj = session.env['carepoint.%s' % model_name].with_context(
+        connector_no_export=True,
+    )
+    if not len(model_obj.search([('odoo_id', '=', record_id)])):
+        model_obj.create({
+            'odoo_id': record_id,
+        })
+    delay_export_all_bindings(session, model_name, record_id, vals)
 
 
 # @on_record_unlink(model_names=['carepoint.medical.patient',

--- a/connector_carepoint/consumer.py
+++ b/connector_carepoint/consumer.py
@@ -31,7 +31,9 @@ def delay_export(session, model_name, record_id, vals):
     export_record.delay(session, model_name, record_id, fields=fields)
 
 
-@on_record_write(model_names=['carepoint.address',
+@on_record_write(model_names=['medical.patient',
+                              'carepoint.address',
+                              'carepoint.address.patient',
                               ])
 def delay_export_all_bindings(session, model_name, record_id, vals):
     """ Delay a job which export all the bindings of a record.
@@ -47,7 +49,9 @@ def delay_export_all_bindings(session, model_name, record_id, vals):
                             fields=fields)
 
 
-@on_record_create(model_names=['carepoint.address',
+@on_record_create(model_names=['medical.patient',
+                               'carepoint.address',
+                               'carepoint.address.patient',
                                ])
 def delay_create(session, model_name, record_id, vals):
     """ Create a new binding record, then trigger delayed export

--- a/connector_carepoint/models/medical_patient.py
+++ b/connector_carepoint/models/medical_patient.py
@@ -17,7 +17,7 @@ from ..backend import carepoint
 from ..unit.import_synchronizer import (DelayedBatchImporter,
                                         CarepointImporter,
                                         )
-from ..unit.export_synchronizer import (CarepointExporter)
+from ..unit.export_synchronizer import CarepointExporter
 
 from .address_patient import CarepointAddressPatientUnit
 
@@ -76,7 +76,12 @@ class MedicalPatientImportMapper(PersonImportMapper):
         (trim('email'), 'email'),
         ('birth_date', 'dob'),
         ('death_date', 'dod'),
+        ('pat_status_cn', 'active'),
     ]
+
+    @mapping
+    def safety_cap_yn(self, record):
+        return {'safety_caps_yn': not record['no_safety_caps_yn']}
 
     @mapping
     def gender(self, record):
@@ -124,19 +129,40 @@ class MedicalPatientExportMapper(PersonExportMapper):
         ('email', 'email'),
         ('dob', 'birth_date'),
         ('dod', 'death_date'),
+        ('active', 'pat_status_cn')
     ]
-
-    @mapping
-    def pat_id(self, record):
-        return {'pat_id': record.carepoint_id}
 
     @mapping
     @changed_by('gender')
     def gender_cd(self, record):
-        return {'gender_cd': record.get('gender').upper()}
+        if record.gender:
+            return {'gender_cd': record.gender.upper()}
+
+    @mapping
+    def static_defaults(self, record):
+        """ It provides all static default mappings """
+        return {
+            'pat_type_cn': 1,
+            'bad_check_yn': 0,
+            'app_flags': 0,
+            'comp_cn': 0,
+            'status_cn': 0,
+        }
+
+    @mapping
+    @changed_by('safety_cap_yn')
+    def no_safety_caps_yn(self, record):
+        return {'no_safety_caps_yn': not record.safety_cap_yn}
 
 
 @carepoint
 class MedicalPatientExporter(CarepointExporter):
     _model_name = ['carepoint.medical.patient']
     _base_mapper = MedicalPatientExportMapper
+
+    def _after_export(self):
+        self.env['carepoint.address.patient']._get_by_partner(
+            self.binding_record.commercial_partner_id,
+            edit=True,
+            recurse=True,
+        )

--- a/connector_carepoint/tests/models/__init__.py
+++ b/connector_carepoint/tests/models/__init__.py
@@ -20,3 +20,4 @@ from . import test_address_patient
 from . import test_address_store
 from . import test_address_organization
 from . import test_address_physician
+from . import test_medical_patient

--- a/connector_carepoint/tests/models/test_address_abstract.py
+++ b/connector_carepoint/tests/models/test_address_abstract.py
@@ -57,11 +57,12 @@ class TestCarepointAddressAbstract(AddressAbstractTestBase):
         return self.env['carepoint.address'].create(vals)
 
     def new_patient_address(self):
-        patient = self.new_patient()
-        self.address = self.new_address(patient.partner_id)
+        self.patient = self.new_patient()
+        self.address = self.new_address(self.patient.partner_id)
         return self.model.create({
-            'partner_id': patient.partner_id,
+            'partner_id': self.patient.partner_id.id,
             'address_id': self.address.id,
+            'res_model': 'medical.patient',
         })
 
     def test_compute_partner_id(self):
@@ -92,6 +93,65 @@ class TestCarepointAddressAbstract(AddressAbstractTestBase):
         self.assertEqual(
             expect,
             address.street,
+        )
+
+    def test_medical_entity_id(self):
+        """ It should return patient record """
+        address = self.new_patient_address()
+        self.assertEqual(
+            self.patient,
+            address.medical_entity_id,
+        )
+
+    def test_compute_res_id(self):
+        """ It should compute the Resource ID for record """
+        address = self.new_patient_address()
+        self.assertEqual(
+            self.patient.id,
+            address.res_id,
+        )
+
+    def test_compute_res_id_empty(self):
+        """ It should continue when resource isn't known """
+        address = self.new_patient_address()
+        address.res_model = False
+        self.assertFalse(
+            address.res_id,
+        )
+
+    def test_get_by_partner_existing_address(self):
+        """ It should return partner associated with existing address """
+        address = self.new_patient_address()
+        res = address._get_by_partner(address.partner_id, False, False)
+        self.assertEqual(address, res)
+
+    def test_get_by_partner_create(self):
+        """ It should create new address when non-exist and edit """
+        patient = self.new_patient()
+        res = self.model._get_by_partner(patient.partner_id, True, False)
+        self.assertEqual(patient.partner_id, res.partner_id)
+
+    def test_get_by_partner_edit(self):
+        """ It should update vals on address when edit and existing """
+        expect = 'expect'
+        address = self.new_patient_address()
+        address.partner_id.street = expect
+        res = address._get_by_partner(address.partner_id, True, False)
+        self.assertEqual(expect, res.street)
+
+    def test_get_by_partner_recurse(self):
+        """ It should recurse into children when edit and recurse """
+        parent, child = self.new_patient(), self.new_patient()
+        child.parent_id = parent.partner_id.id
+        self.model._get_by_partner(parent.partner_id, True, True)
+        address = self.model.search([('partner_id', '=', child.partner_id.id)])
+        self.assertTrue(len(address))
+
+    def test_compute_partner_id(self):
+        address = self.new_patient_address()
+        self.assertEqual(
+            self.patient.partner_id.id,
+            address.partner_id.id,
         )
 
 
@@ -172,6 +232,16 @@ class TestAddressAbstractImportMapper(AddressAbstractTestBase):
             expect = self.unit.binder_for().to_odoo()
             self.assertDictEqual({'address_id': expect}, res)
 
+    def test_res_model_and_id(self):
+        """ It should return values dict for medical entity """
+        entity = mock.MagicMock()
+        expect = {
+            'res_id': entity.id,
+            'res_model': entity._name,
+        }
+        res = self.unit.res_model_and_id(None, entity)
+        self.assertDictEqual(expect, res)
+
 
 class TestAddressAbstractImporter(AddressAbstractTestBase):
 
@@ -188,6 +258,70 @@ class TestAddressAbstractImporter(AddressAbstractTestBase):
             mk.assert_has_calls([
                 mock.call(
                     self.record['addr_id'],
+                    'carepoint.carepoint.address',
+                ),
+            ])
+
+
+class TestAddressAbstractExportMapper(AddressAbstractTestBase):
+
+    def setUp(self):
+        super(TestAddressAbstractExportMapper, self).setUp()
+        self.Unit = address_abstract.CarepointAddressAbstractExportMapper
+        self.unit = self.Unit(self.mock_env)
+        self.record = mock.MagicMock()
+
+    def test_addr_id_get_binder(self):
+        """ It should get binder for prescription line """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.addr_id(self.record)
+            self.unit.binder_for.assert_called_once_with(
+                'carepoint.carepoint.address'
+            )
+
+    def test_addr_id_to_backend(self):
+        """ It should get backend record for rx """
+        with mock.patch.object(self.unit, 'binder_for'):
+            self.unit.binder_for().to_backend.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                self.unit.addr_id(self.record)
+            self.unit.binder_for().to_backend.assert_called_once_with(
+                self.record.address_id.id,
+            )
+
+    def test_addr_id_return(self):
+        """ It should return formatted addr_id """
+        with mock.patch.object(self.unit, 'binder_for'):
+            res = self.unit.addr_id(self.record)
+            expect = self.unit.binder_for().to_backend()
+            self.assertDictEqual({'addr_id': expect}, res)
+
+    def test_static_defaults(self):
+        """ It should return a dict of default values """
+        self.assertIsInstance(
+            self.unit.static_defaults(self.record),
+            dict,
+        )
+
+
+class TestAddressAbstractExporter(AddressAbstractTestBase):
+
+    def setUp(self):
+        super(TestAddressAbstractExporter, self).setUp()
+        self.Unit = address_abstract.CarepointAddressAbstractExporter
+        self.unit = self.Unit(self.mock_env)
+        self.record = mock.MagicMock()
+        self.unit.binding_record = self.record
+
+    def test_export_dependencies(self):
+        """ It should export all dependencies """
+        with mock.patch.object(self.unit, '_export_dependency') as mk:
+            self.unit._export_dependencies()
+            mk.assert_has_calls([
+                mock.call(
+                    self.record.address_id,
                     'carepoint.carepoint.address',
                 ),
             ])

--- a/connector_carepoint/tests/models/test_medical_patient.py
+++ b/connector_carepoint/tests/models/test_medical_patient.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from openerp.addons.connector_carepoint.models import medical_patient
+
+from ..common import SetUpCarepointBase
+
+
+class EndTestException(Exception):
+    pass
+
+
+class MedicalPatientTestBase(SetUpCarepointBase):
+
+    def setUp(self):
+        super(MedicalPatientTestBase, self).setUp()
+        self.model = 'carepoint.medical.patient'
+        self.mock_env = self.get_carepoint_helper(
+            self.model
+        )
+        self.record = {
+            'no_safety_caps_yn': True,
+            'pat_id': 1,
+            'gender_cd': 'M',
+            'birth_date': '2016-09-10',
+            'fname': 'FirstName',
+            'lname': 'LastName',
+        }
+
+
+class TestMedicalPatientImportMapper(MedicalPatientTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientImportMapper, self).setUp()
+        self.Unit = medical_patient.MedicalPatientImportMapper
+        self.unit = self.Unit(self.mock_env)
+
+    def _create_patient(self):
+        return self.env['medical.patient'].create({
+            'name': '%s %s' % (self.record['fname'],
+                               self.record['lname']),
+            'dob': self.record['birth_date'],
+        })
+
+    def test_safety_caps_yn(self):
+        """ It should return proper dict vals """
+        self.assertDictEqual(
+            {'safety_caps_yn': False},
+            self.unit.safety_cap_yn(self.record),
+        )
+
+    def test_gender_exist(self):
+        """ It should return lowercase gender code """
+        self.assertDictEqual(
+            {'gender': self.record['gender_cd'].lower()},
+            self.unit.gender(self.record)
+        )
+
+    def test_gender_none(self):
+        """ It should return None when no gender """
+        self.record['gender_cd'] = False
+        self.assertDictEqual(
+            {'gender': None},
+            self.unit.gender(self.record)
+        )
+
+    def test_carepoint_id(self):
+        """ It should return lowercase gender code """
+        self.assertDictEqual(
+            {'carepoint_id': self.record['pat_id']},
+            self.unit.carepoint_id(self.record)
+        )
+
+    def test_odoo_id(self):
+        """ It should return odoo_id of patient with same name """
+        expect = self._create_patient()
+        res = self.unit.odoo_id(self.record)
+        expect = {'odoo_id': expect.id}
+        self.assertDictEqual(expect, res)
+
+
+class TestMedicalPatientImporter(MedicalPatientTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientImporter, self).setUp()
+        self.Unit = medical_patient.MedicalPatientImporter
+        self.unit = self.Unit(self.mock_env)
+        self.unit.carepoint_record = self.record
+
+    def test_after_import_get_unit(self):
+        """ It should get unit for address importer """
+        expect = mock.MagicMock()
+        with mock.patch.object(self.unit, 'unit_for'):
+            self.unit._after_import(expect)
+            self.unit.unit_for.assert_called_once_with(
+                medical_patient.CarepointAddressPatientUnit,
+                model='carepoint.carepoint.address.patient',
+            )
+
+    def test_after_import_get_unit(self):
+        """ It should get unit for address importer """
+        expect = mock.MagicMock()
+        with mock.patch.object(self.unit, 'unit_for'):
+            self.unit._after_import(expect)
+            self.unit.unit_for()._import_addresses.assert_called_once_with(
+                self.unit.carepoint_id,
+                expect,
+            )
+
+
+class TestMedicalPatientExportMapper(MedicalPatientTestBase):
+
+    def setUp(self):
+        super(TestMedicalPatientExportMapper, self).setUp()
+        self.Unit = medical_patient.MedicalPatientExportMapper
+        self.unit = self.Unit(self.mock_env)
+        self.record = mock.MagicMock()
+
+    def test_gender_cd(self):
+        """ It should return proper export vals dict """
+        self.assertDictEqual(
+            {'gender_cd': self.record.gender.upper()},
+            self.unit.gender_cd(self.record),
+        )
+
+    def test_static_defaults(self):
+        """ It should return a dict of default values """
+        self.assertIsInstance(
+            self.unit.static_defaults(self.record),
+            dict,
+        )
+
+    def test_no_safety_caps_yn(self):
+        """ It should return negated safety_caps """
+        self.assertFalse(
+            self.unit.no_safety_caps_yn(self.record)[
+                'no_safety_caps_yn'
+            ],
+        )

--- a/connector_carepoint/unit/export_synchronizer.py
+++ b/connector_carepoint/unit/export_synchronizer.py
@@ -88,7 +88,7 @@ class CarepointBaseExporter(Exporter):
 
         self.binding_id = binding_id
         self.binding_record = self._get_odoo_data()
-        self.carepoint_id = self.binder.to_backend(self.binding_id)
+        self.carepoint_id = self.binding_record.carepoint_id
 
         try:
             should_import = self._should_import()


### PR DESCRIPTION
Unfortunately couldn't split the PRs the way I wanted & still provide tests on the abstract model. Oh well 😦 

[FIX] connector_carepoint: Fix create and write functionality
- Add primary key injection in create
- Prefer Pk return in create to Recordset - comma join in col order
- Remove carepoint update method in favor of custom write logic
- Fix export synchronizer carepoint_id assignment

[ADD] connector_carepoint: Patient & Address export logic
- Improve existing patient export
- Add tests for patient importer/exporter
- Add abstract address export logic
- Add patient address export logic
