### PR TITLE
[9.0][FIX] connector_carepoint: Remove TZ from import time

### DIFF
--- a/connector_carepoint/models/carepoint_backend.py
+++ b/connector_carepoint/models/carepoint_backend.py
@@ -273,7 +273,9 @@ class CarepointBackend(models.Model):
         utc_now = pytz.timezone('UTC').localize(datetime.utcnow())
         for backend in self:
             local_tz = pytz.timezone(backend.server_tz)
-            import_start_time = utc_now.astimezone(local_tz)
+            import_start_time = utc_now.astimezone(local_tz).replace(
+                tzinfo=None
+            )
             backend.check_carepoint_structure()
             filters = {chg_date_field: {'<=': import_start_time}}
             from_date = getattr(backend, from_date_field)

--- a/connector_carepoint/tests/test_carepoint_backend.py
+++ b/connector_carepoint/tests/test_carepoint_backend.py
@@ -88,7 +88,9 @@ class TestCarepointBackend(SetUpCarepointBase):
         self.backend.import_patients_from_date = expect_date
         expect_date = self.backend.import_patients_from_date
         self.backend._import_from_date(*expect)
-        utc_now = pytz.timezone('UTC').localize(dt_mk.utcnow())
+        utc_now = pytz.timezone('UTC').localize(dt_mk.utcnow()).astimezone(
+            pytz.timezone(self.backend.server_tz)
+        )
         batch.delay.assert_called_once_with(
             session(), expect[0], self.backend.id,
             filters={
@@ -96,7 +98,7 @@ class TestCarepointBackend(SetUpCarepointBase):
                     '>=': fields.Datetime.from_string(
                         expect_date,
                     ),
-                    '<=': utc_now,
+                    '<=': utc_now.replace(tzinfo=None),
                 },
             }
         )


### PR DESCRIPTION
* Remove timezone from the `import_start_time` as the TZ info isn’t pickle-able

